### PR TITLE
Use Html component from next/document

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components'
 import { ServerStyleSheets } from '@material-ui/styles';
 import theme from '../src/theme';
@@ -32,7 +32,7 @@ class MyDocument extends Document {
 
   render() {
     return (
-      <html lang="en" dir="ltr">
+      <Html lang="en" dir="ltr">
         <Head>
           <meta charSet="utf-8" />
           {/* PWA primary color */}
@@ -49,7 +49,7 @@ class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }


### PR DESCRIPTION
There is a warning in the console:

```
Expected Document Component Html was not rendered. Make sure you render them in your custom `_document`
See more info here https://err.sh/next.js/missing-document-component
```